### PR TITLE
Feature: Use bulkUpsert() when saving candles 1.0.2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.2
+- refactor: use bulkUpsert() if available when saving candles
+
 # 1.0.1
 - docs: create/update
 

--- a/lib/models/candle/sync_range.js
+++ b/lib/models/candle/sync_range.js
@@ -37,7 +37,7 @@ module.exports = async (candleModel, {
     start,
     end
   }, onSyncStart = () => {}, onSyncEnd = () => {}) => {
-  const { getInRange, auditGaps, upsert } = candleModel
+  const { getInRange, auditGaps, bulkUpsert, upsert } = candleModel
   const width = TIME_FRAME_WIDTHS[tf]
   const existingCandles = await getInRange([
     ['exchange', '=', exchange],
@@ -190,6 +190,17 @@ module.exports = async (candleModel, {
       const consistent = preprocessRemoteCandles(tf, candles, true)
 
       debug('saving %d candles', consistent.length)
+
+      if (bulkUpsert) { // not on all DB adapters
+        return bulkUpsert(consistent.map(c => ({
+          ...c,
+
+          key: `${exchange}-${symbol}-${tf}-${c.mts}`,
+          exchange,
+          symbol,
+          tf
+        })))
+      }
 
       return PI.forEachSeries(consistent, c => {
         return upsert({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ext-plugin-bitfinex",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Bitfinex exchange plugin for the Honey Framework",
   "license": "Apache-2.0",
   "author": "Bitfinex",


### PR DESCRIPTION
### Description:
Updates the Candle model `sync_range` method to use `bulkUpsert()` if it's available on the DB adapter for saving candles. Much faster.

### New features:
- [x] use `bulkUpsert()` if available when saving candles

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
