### PR TITLE
Fix: Ceanup timeouts on ao adapter disconnect, 1.0.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ _test.js
 _test_candle_data.json
 !./db.keep
 /db/*.json
+tags
+db

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.0.6
+- fix: cleanup timeouts on AOAdapter disconnect()
+
 # 1.0.5
 - feature: add updateAuthArgs() to AOAdapter
 

--- a/lib/ao_adapter/index.js
+++ b/lib/ao_adapter/index.js
@@ -33,7 +33,7 @@ module.exports = class AOAdapter extends EventEmitter {
       '1 Day': '1D',
       '7 Days': '7D',
       '14 Days': '14D',
-      '1 Month': '1M',
+      '1 Month': '1M'
     }
   }
 
@@ -42,6 +42,7 @@ module.exports = class AOAdapter extends EventEmitter {
   }) {
     super()
 
+    this.pendingOrderSubmitCancelTimeouts = []
     this.affiliateCode = affiliateCode
     this.hbEnabled = withHeartbeat
     this.hbInterval = null
@@ -109,13 +110,26 @@ module.exports = class AOAdapter extends EventEmitter {
     }
   }
 
+  /**
+    * @return {Promise} p
+    */
   disconnect () {
     if (this.hbInterval !== null) {
       clearInterval(this.hbInterval)
       this.hbInterval = null
     }
 
-    this.m.closeAllSockets()
+    // Clean up pending actions
+    this.pendingOrderSubmitCancelTimeouts.forEach(timeoutObject => {
+      if (timeoutObject.t !== null) {
+        clearTimeout(timeoutObject.t)
+        timeoutObject.t = null
+      }
+    })
+
+    this.pendingOrderSubmitCancelTimeouts = []
+
+    return this.m.closeAllSockets()
   }
 
   sendHB () {
@@ -200,11 +214,16 @@ module.exports = class AOAdapter extends EventEmitter {
     }
 
     return new Promise((resolve, reject) => {
-      setTimeout(() => {
+      const t = setTimeout(() => {
+        timeoutObject.t = null
+
         submitOrder(c, order)
           .then(resolve)
           .catch(reject)
       }, delay)
+
+      const timeoutObject = { t }
+      this.pendingOrderSubmitCancelTimeouts.push(timeoutObject)
     })
   }
 
@@ -212,11 +231,16 @@ module.exports = class AOAdapter extends EventEmitter {
     const { c } = connection
 
     return new Promise((resolve, reject) => {
-      setTimeout(() => {
+      const t = setTimeout(() => {
+        timeoutObject.t = null
+
         cancelOrder(c, order)
           .then(resolve)
           .catch(reject)
       }, delay)
+
+      const timeoutObject = { t }
+      this.pendingOrderSubmitCancelTimeouts.push(timeoutObject)
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-ext-plugin-bitfinex",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Bitfinex exchange plugin for the Honey Framework",
   "license": "Apache-2.0",
   "author": "Bitfinex",


### PR DESCRIPTION
### Fixes:
- [x] order submit/cancel timeouts are now tracked and cleared if pending on AO adapter `disconnect()`

### PR status:
- [x] Version bumped
- [x] Change-log updated
- [ ] Tests added or updated
- [ ] Documentation updated
